### PR TITLE
Fixed a problem about name-clash of object file

### DIFF
--- a/tests/merge_object/xmake.lua
+++ b/tests/merge_object/xmake.lua
@@ -41,5 +41,5 @@ target("test")
 
     -- add files
     add_files("src/test.c") 
-    add_files("build/.objs/merge_object/src/interface.o") 
+    add_files("build/.objs/merge_object/src/interface.c.o")
 

--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -283,7 +283,8 @@ function target:objectfiles()
         sourcefile = sourcefile:gsub(target.filename("([%w_]+)", "static"):gsub("%.", "%%.") .. "$", "%1/*")
 
         -- make object file
-        local objectfile = string.format("%s/%s/%s/%s", objectdir, self:name(), path.directory(sourcefile), target.filename(path.basename(sourcefile), "object"))
+        -- full file name(not base) to avoid name-clash of object file
+        local objectfile = string.format("%s/%s/%s/%s", objectdir, self:name(), path.directory(sourcefile), target.filename(sourcefile, "object"))
 
         -- translate path
         --

--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -284,7 +284,7 @@ function target:objectfiles()
 
         -- make object file
         -- full file name(not base) to avoid name-clash of object file
-        local objectfile = string.format("%s/%s/%s/%s", objectdir, self:name(), path.directory(sourcefile), target.filename(sourcefile, "object"))
+        local objectfile = string.format("%s/%s/%s/%s", objectdir, self:name(), path.directory(sourcefile), target.filename(path.filename(sourcefile), "object"))
 
         -- translate path
         --


### PR DESCRIPTION
There is a not serious problem in your build system when building projects blending with both c and c++ ,I think.
It is that when c source and cpp source have the same base name,one of their object file will be overwrited by another,so the build will fail because of some missing reference.I've prepared a example to make it clearer: [testXmake.tar.gz](https://github.com/waruqi/xmake/files/531298/testXmake.tar.gz).
And because it's a small problem.I fixed it myself instead of writing an issue.It may work and help.